### PR TITLE
Implemented Space Encoding #15

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -34,3 +34,13 @@ func comparePath(path1 string, path2 string, reference string) string {
 	}
 	return path2
 }
+
+// Returns the correct path where encodings have been replaced
+func ResourceToPath(resource string) string {
+	return strings.ReplaceAll(resource, "+", " ")
+}
+
+// Returns the correct resource for a path with space
+func PathToResource(path string) string {
+	return strings.ReplaceAll(path, " ", "+")
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,43 @@
+package httphelper
+
+import (
+	"testing"
+)
+
+func TestPathToResource(t *testing.T) {
+	path := "/home/lmao/Vault/Artificial Inteligence/Lecture 5.md"
+	actual := PathToResource(path)
+	expected := "/home/lmao/Vault/Artificial+Inteligence/Lecture+5.md"
+
+	if actual != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
+}
+
+func TestResourceToPath(t *testing.T) {
+	resource := "/home/lmao/Vault/Artificial+Inteligence/Lecture+5.md"
+	actual := ResourceToPath(resource)
+	expected := "/home/lmao/Vault/Artificial Inteligence/Lecture 5.md"
+
+	if actual != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
+}
+
+func TestPathToResourceNoSpace(t *testing.T) {
+	path := "/home/lmao/Vault/ArtificialInteligence/Lecture5.md"
+	actual := PathToResource(path)
+
+	if actual != path {
+		t.Errorf("Expected %s Got %s", path, actual)
+	}
+}
+
+func TestResourceToPathNoSpace(t *testing.T) {
+	resource := "/Vault/lecture-4.md"
+	actual := ResourceToPath(resource)
+
+	if actual != resource {
+		t.Errorf("Expected %s Got %s", resource, actual)
+	}
+}

--- a/http.go
+++ b/http.go
@@ -139,6 +139,7 @@ func ReadRequest(conn net.Conn) Request {
 // Client side code
 func WriteRequest(method string, location string, header Header, body Body) []byte {
 	var data []byte
+	location = PathToResource(location)
 	switch strings.ToLower(method) {
 	case "get":
 		data = WriteGetRequest(location, header)

--- a/http_test.go
+++ b/http_test.go
@@ -1,6 +1,7 @@
 package httphelper
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -18,10 +19,13 @@ func TestReadResponse(t *testing.T) {
 	//"Content-Length": []string{"11"},
 	//}
 
+	ActualData := Body{}
+	json.Unmarshal(actualResponse, &ActualData)
+
 	expectedStatus := Status{Code: 200}
 
-	if actualResponse.Data != expectedResponse.Data {
-		t.Errorf("Got %s, expected %s", actualResponse.Data, expectedResponse.Data)
+	if ActualData.Data != expectedResponse.Data {
+		t.Errorf("Got %s, expected %s", ActualData.Data, expectedResponse.Data)
 	}
 
 	// if !reflect.DeepEqual(actualHeaders, expectedHeaders) {


### PR DESCRIPTION
As mentioned in #15 previously paths would not be correctly transla- ted into resource URLs if the had space characters in their name. Now implmeneted two functions in helpers which translate Paths and URLs between each other and space is encoded as '+'.